### PR TITLE
fix(backend): add Yahoo-backed fallback when SEC facts time out (#1)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,18 +11,31 @@ RUN mvn dependency:go-offline -B 2>/dev/null || true
 COPY src ./src
 RUN mvn package -DskipTests -q
 
-## ---- Stage 2: Runtime (JRE only) ----
-FROM eclipse-temurin:21-jre-alpine
+## ---- Stage 2: Runtime ----
+##
+## Render's Docker runtime was missing `python3`, which breaks the Yahoo
+## enrichment helper invoked by YahooFinanceMarketDataService. We intentionally
+## use the Debian-based Temurin image here instead of Alpine because Python
+## wheels (pandas/numpy/yfinance transitive deps) are much more reliable on it.
+FROM eclipse-temurin:21-jre
 
 WORKDIR /app
 
-# Install curl for healthcheck
-RUN apk add --no-cache curl
+# Install runtime dependencies for:
+# - health checks (`curl`)
+# - Yahoo Finance helper (`python3`, `pip`)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 COPY --from=build /app/target/*.jar app.jar
 
 EXPOSE 8081
 
 ENV JAVA_OPTS="-Xms128m -Xmx384m -XX:+UseContainerSupport -XX:MaxMetaspaceSize=128m -XX:+UseSerialGC"
+ENV PYTHON_BIN="/usr/bin/python3"
 
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/backend/src/main/java/com/springalpha/backend/financial/service/HybridFinancialDataService.java
+++ b/backend/src/main/java/com/springalpha/backend/financial/service/HybridFinancialDataService.java
@@ -150,6 +150,12 @@ public class HybridFinancialDataService implements FinancialDataService {
             return fallbackFacts;
         }
 
+        FinancialFacts marketBackedFallback = buildMarketBackedMinimalFactsFallback(upperTicker, reportType);
+        if (marketBackedFallback != null) {
+            cacheFinancialFacts(upperTicker, reportType, marketBackedFallback);
+            return marketBackedFallback;
+        }
+
         log.warn("⚠️ SEC core financial facts unavailable for {}. Main analysis path will stop here.", upperTicker);
         return null;
     }
@@ -356,11 +362,104 @@ public class HybridFinancialDataService implements FinancialDataService {
         }
     }
 
+    private FinancialFacts buildMarketBackedMinimalFactsFallback(String ticker, String reportType) {
+        if (marketEnrichmentService == null) {
+            return null;
+        }
+
+        try {
+            MarketSupplementalData supplementalData = marketEnrichmentService.getSupplementalData(ticker, reportType);
+            MarketSupplementalData.QuarterlyFinancialSnapshot snapshot = latestQuarterlySnapshot(
+                    supplementalData == null ? null : supplementalData.quarterlyFinancials());
+            if (snapshot == null) {
+                return null;
+            }
+
+            FinancialFacts fallbackFacts = FinancialFacts.builder()
+                    .ticker(ticker)
+                    .companyName(firstNonBlank(supplementalData.companyName(), ticker))
+                    .period(deriveQuarterlyPeriodLabel(snapshot.periodEnd()))
+                    .filingDate(snapshot.periodEnd())
+                    .marketSector(supplementalData.sector())
+                    .marketIndustry(supplementalData.industry())
+                    .marketSecurityType(supplementalData.securityType())
+                    .marketBusinessSummary(supplementalData.businessSummary())
+                    .revenue(snapshot.revenue())
+                    .grossProfit(snapshot.grossProfit())
+                    .grossMargin(divide(snapshot.grossProfit(), snapshot.revenue()))
+                    .operatingIncome(snapshot.operatingIncome())
+                    .operatingMargin(divide(snapshot.operatingIncome(), snapshot.revenue()))
+                    .netIncome(snapshot.netIncome())
+                    .netMargin(divide(snapshot.netIncome(), snapshot.revenue()))
+                    .operatingCashFlow(snapshot.operatingCashFlow())
+                    .freeCashFlow(snapshot.freeCashFlow())
+                    .priceToEarningsRatio(supplementalData.priceToEarningsRatio())
+                    .priceToBookRatio(supplementalData.priceToBookRatio())
+                    .build();
+
+            applyQuarterlyGrowthFallbacks(fallbackFacts, snapshot, supplementalData.quarterlyFinancials());
+
+            if (hasMarketClassificationInputs(supplementalData)) {
+                DashboardModeClassifier.DashboardMode dashboardMode = DashboardModeClassifier.classify(fallbackFacts,
+                        supplementalData);
+                fallbackFacts.setDashboardMode(dashboardMode.mode());
+                fallbackFacts.setDashboardMessage(dashboardMode.message());
+            }
+
+            log.info(
+                    "🪂 Returning market-backed minimal facts for {} because SEC core facts were unavailable (snapshot={}, revenue={}, netIncome={})",
+                    ticker,
+                    snapshot.periodEnd(),
+                    snapshot.revenue(),
+                    snapshot.netIncome());
+            return fallbackFacts;
+        } catch (Exception e) {
+            log.warn("⚠️ Market-backed minimal facts fallback failed for {}: {}", ticker, e.getMessage());
+            return null;
+        }
+    }
+
     private String firstNonBlank(String preferred, String fallback) {
         if (preferred != null && !preferred.isBlank()) {
             return preferred;
         }
         return fallback;
+    }
+
+    private MarketSupplementalData.QuarterlyFinancialSnapshot latestQuarterlySnapshot(
+            List<MarketSupplementalData.QuarterlyFinancialSnapshot> snapshots) {
+        if (snapshots == null || snapshots.isEmpty()) {
+            return null;
+        }
+
+        MarketSupplementalData.QuarterlyFinancialSnapshot best = null;
+        LocalDate bestDate = null;
+        for (MarketSupplementalData.QuarterlyFinancialSnapshot snapshot : snapshots) {
+            if (snapshot == null) {
+                continue;
+            }
+            LocalDate current = parsePeriodEnd(snapshot.periodEnd());
+            if (current == null) {
+                if (best == null) {
+                    best = snapshot;
+                }
+                continue;
+            }
+            if (bestDate == null || current.isAfter(bestDate)) {
+                best = snapshot;
+                bestDate = current;
+            }
+        }
+        return best;
+    }
+
+    private String deriveQuarterlyPeriodLabel(String periodEnd) {
+        LocalDate date = parsePeriodEnd(periodEnd);
+        if (date == null) {
+            return null;
+        }
+        int quarter = ((date.getMonthValue() - 1) / 3) + 1;
+        return "Q" + quarter + " " + date.getYear();
     }
 
     private MarketSupplementalData.QuarterlyFinancialSnapshot matchQuarterlySnapshot(

--- a/backend/src/test/java/com/springalpha/backend/financial/service/HybridFinancialDataServiceTest.java
+++ b/backend/src/test/java/com/springalpha/backend/financial/service/HybridFinancialDataServiceTest.java
@@ -561,6 +561,80 @@ class HybridFinancialDataServiceTest {
     }
 
     @Test
+    void returnsMarketBackedMinimalFactsWhenSecLookupFailsButYahooQuarterlySnapshotsExist() {
+        SecCompanyFactsFinancialDataService secService = mock(SecCompanyFactsFinancialDataService.class);
+        MarketEnrichmentService enrichmentService = mock(MarketEnrichmentService.class);
+
+        when(secService.getFinancialFacts("GOOG", "quarterly")).thenReturn(null);
+        when(enrichmentService.getSupplementalData("GOOG", "quarterly")).thenReturn(new MarketSupplementalData(
+                "yfinance",
+                true,
+                true,
+                true,
+                "Alphabet Inc.",
+                "Technology",
+                "Internet Content & Information",
+                "EQUITY",
+                new BigDecimal("182.00"),
+                new BigDecimal("2200000000000"),
+                new BigDecimal("23.1000"),
+                new BigDecimal("7.8000"),
+                List.of(
+                        new MarketSupplementalData.QuarterlyFinancialSnapshot(
+                                "2025-09-30",
+                                new BigDecimal("102346000000"),
+                                new BigDecimal("60977000000"),
+                                new BigDecimal("31222000000"),
+                                new BigDecimal("34979000000"),
+                                new BigDecimal("41330000000"),
+                                new BigDecimal("28900000000")),
+                        new MarketSupplementalData.QuarterlyFinancialSnapshot(
+                                "2024-09-30",
+                                new BigDecimal("88268000000"),
+                                new BigDecimal("52662000000"),
+                                new BigDecimal("28262000000"),
+                                new BigDecimal("26301000000"),
+                                new BigDecimal("34000000000"),
+                                new BigDecimal("24000000000"))),
+                null,
+                "Alphabet is a technology company focused on search, cloud, and digital advertising."));
+
+        HybridFinancialDataService service = new HybridFinancialDataService(
+                secService,
+                enrichmentService,
+                null,
+                Duration.ofHours(6),
+                Duration.ofHours(24));
+
+        FinancialFacts facts = service.getFinancialFacts("GOOG", "quarterly");
+
+        assertNotNull(facts);
+        assertEquals("GOOG", facts.getTicker());
+        assertEquals("Alphabet Inc.", facts.getCompanyName());
+        assertEquals("Q3 2025", facts.getPeriod());
+        assertEquals("2025-09-30", facts.getFilingDate());
+        assertEquals(new BigDecimal("102346000000"), facts.getRevenue());
+        assertEquals(new BigDecimal("60977000000"), facts.getGrossProfit());
+        assertEquals(new BigDecimal("0.5958"), facts.getGrossMargin());
+        assertEquals(new BigDecimal("31222000000"), facts.getOperatingIncome());
+        assertEquals(new BigDecimal("0.3051"), facts.getOperatingMargin());
+        assertEquals(new BigDecimal("34979000000"), facts.getNetIncome());
+        assertEquals(new BigDecimal("0.3418"), facts.getNetMargin());
+        assertEquals(new BigDecimal("41330000000"), facts.getOperatingCashFlow());
+        assertEquals(new BigDecimal("28900000000"), facts.getFreeCashFlow());
+        assertEquals(new BigDecimal("0.1595"), facts.getRevenueYoY());
+        assertEquals(new BigDecimal("0.2156"), facts.getOperatingCashFlowYoY());
+        assertEquals(new BigDecimal("0.2042"), facts.getFreeCashFlowYoY());
+        assertEquals("Technology", facts.getMarketSector());
+        assertEquals("Internet Content & Information", facts.getMarketIndustry());
+        assertEquals("EQUITY", facts.getMarketSecurityType());
+        assertEquals(new BigDecimal("23.1000"), facts.getPriceToEarningsRatio());
+        assertEquals(new BigDecimal("7.8000"), facts.getPriceToBookRatio());
+        assertEquals("standard", facts.getDashboardMode());
+        assertNull(facts.getDashboardMessage());
+    }
+
+    @Test
     void backfillsDashboardMetadataForCachedFactsFromOlderSchema() {
         SecCompanyFactsFinancialDataService secService = mock(SecCompanyFactsFinancialDataService.class);
         MarketEnrichmentService enrichmentService = mock(MarketEnrichmentService.class);


### PR DESCRIPTION
Closes #1

## Root cause
- SEC company facts could time out for some tickers (e.g. GOOG)
- Yahoo enrichment fallback was unavailable on Render because python3 was missing from the backend runtime

## Fix
- install python3 + pip + yfinance dependencies in backend runtime image
- add a Yahoo-backed minimal FinancialFacts fallback when SEC facts are unavailable but quarterly snapshots exist

## Validation
- added HybridFinancialDataService test for:
  - SEC facts unavailable
  - Yahoo quarterly snapshots available
  - expected behavior: return minimal facts instead of null
